### PR TITLE
Add kernel to dependencies

### DIFF
--- a/src/quickrand.app.src
+++ b/src/quickrand.app.src
@@ -3,6 +3,6 @@
    {vsn, "1.3.0"},
    {modules, [quickrand, random_wh06_int]},
    {registered, []},
-   {applications, [crypto, stdlib]},
+   {applications, [crypto, kernel, stdlib]},
    {start_phases, []}]}.
 


### PR DESCRIPTION
This is to prevent some lock-up problems when using init:stop to bring down a node.
