### PR TITLE
Fix Elixir compile warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Quickrand.Mixfile do
      version: "2.0.7",
      language: :erlang,
      erlc_options: [
-       {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
+       {:d, String.to_atom("ERLANG_OTP_VERSION_" <> to_string(System.otp_release()))},
        :deterministic,
        :debug_info,
        :warn_export_vars,


### PR DESCRIPTION
```
 $ mix compile
    warning: using single-quoted strings to represent charlists is deprecated.
    Use ~c"" if you indeed want a charlist or use "" instead.
    You may run "mix format --migrate" to change all single-quoted
    strings to use the ~c sigil and fix this warning.
    │
 12 │        {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
    │                                  ~
    │
    └─ mix.exs:12:34
```